### PR TITLE
Added the ability to specify a port when creating a SnmpHandler.

### DIFF
--- a/nelsnmp/snmp.py
+++ b/nelsnmp/snmp.py
@@ -147,6 +147,11 @@ class SnmpHandler(object):
                 self.community = kwargs[key]
             if key == 'host':
                 self.host = kwargs[key]
+            if key == 'port':
+                if 1 <= kwargs[key] <= 65535:
+                    self.port = kwargs[key]
+                else:
+                    raise ArgumentError('Port must be between 1 and 65535')
             if key == 'username':
                 self.username = kwargs[key]
             if key == 'level':


### PR DESCRIPTION
SnmpHandler now accepts port as an argument. Before it always defaulted to UDP 161.
