### PR TITLE
Ensure version is passed to SNMPHandler

### DIFF
--- a/lib/nelsnmp/snmp.py
+++ b/lib/nelsnmp/snmp.py
@@ -122,11 +122,7 @@ class SnmpHandler(object):
     def _parse_args(self, **kwargs):
         for key in kwargs:
             if key == 'version':
-                if kwargs[key] in VALID_VERSIONS:
-                    self.version = kwargs[key]
-                else:
-                    self._raise_error(ArgumentError,
-                                      'No valid SNMP version defined')
+                self.version = kwargs[key]
             if key == 'community':
                 self.community = kwargs[key]
             if key == 'host':
@@ -169,6 +165,9 @@ class SnmpHandler(object):
 
         if self.host is False:
             self._raise_error(ArgumentError, 'Host not defined')
+
+        if self.version not in VALID_VERSIONS:
+            self._raise_error(ArgumentError, 'No valid SNMP version defined')
 
         if self.version == "2c":
             self.snmp_auth = cmdgen.CommunityData(self.community)

--- a/tests/test_hostinfo.py
+++ b/tests/test_hostinfo.py
@@ -62,13 +62,13 @@ def test_os():
 
 
 def test_hostinfo():
-    handler = SnmpHandler(host='1.1.1.1')
+    handler = SnmpHandler(host='1.1.1.1', version='2c')
     hostinfo = HostInfo(handler)
     assert hostinfo.os is None
 
 
 def test_hostinfo_cisco_ios_version():
-    handler = SnmpHandler(host='1.1.1.1')
+    handler = SnmpHandler(host='1.1.1.1', version='2c')
     hostinfo = HostInfo(
         handler,
         vendor='cisco',
@@ -78,7 +78,7 @@ def test_hostinfo_cisco_ios_version():
 
 
 def test_hostinfo_netsnmp(patch_snmp_getnext):
-    handler = SnmpHandler(host='1.1.1.1')
+    handler = SnmpHandler(host='1.1.1.1', version='2c')
     hostinfo = HostInfo(
         handler,
         vendor='net-snmp',

--- a/tests/test_snmp_invalid_arguments.py
+++ b/tests/test_snmp_invalid_arguments.py
@@ -8,6 +8,14 @@ def test_snmp_missing_host():
         SnmpHandler(version='2c', community='public')
 
 
+def test_snmp_handler_missing_version():
+    with pytest.raises(ArgumentError):
+        SnmpHandler(
+            host='1.1.1.1', username='user',
+            level='authPriv', integrity='sha', privacy='aes',
+            authkey='authpass', privkey='privkey')
+
+
 def test_snmp_handler_invalid_version():
     with pytest.raises(ArgumentError):
         SnmpHandler(


### PR DESCRIPTION
Previously, version was optional, but not specifying it would result in `AttributeError: 'SnmpHandler' object has no attribute 'snmp_auth'` errors during .get() or .set(). Enforce version to be one of the supported versions.

Alternatives explored:
- Default to v2c in _set_defaults()
- Always configure auth_data to CommunityData, except for SNMP v3

Upon inspection of the codebase, never passing a version and avoiding the value check seemed like a bug (version was almost passed everywhere, and VALID_VERSIONS seemed to indicate version "1" or "None" is not supported). This commit fixes that specific bug and version is now mandatory. If you feel otherwise, I'd be happy to adjust the tests and code.
