### PR TITLE
Introduce support for timeout and retries

### DIFF
--- a/lib/nelsnmp/snmp.py
+++ b/lib/nelsnmp/snmp.py
@@ -143,6 +143,10 @@ class SnmpHandler(object):
                 else:
                     self._raise_error(ArgumentError,
                                       'Port must be between 1 and 65535')
+            if key == 'timeout':
+                self.timeout = kwargs[key]
+            if key == 'retries':
+                self.retries = kwargs[key]
             if key == 'username':
                 self.username = kwargs[key]
             if key == 'level':
@@ -208,6 +212,8 @@ class SnmpHandler(object):
 
     def _set_defaults(self):
         self.port = 161
+        self.timeout = 1
+        self.retries = 5
         self.version = False
         self.community = False
         self.host = False
@@ -227,7 +233,9 @@ class SnmpHandler(object):
         cmdGen = cmdgen.CommandGenerator()
         errorIndication, errorStatus, errorIndex, varBinds = cmdGen.getCmd(
             self.snmp_auth,
-            cmdgen.UdpTransportTarget((self.host, self.port)),
+            cmdgen.UdpTransportTarget((self.host, self.port),
+                                      timeout=self.timeout,
+                                      retries=self.retries),
             *snmp_query,
             lookupMib=False
         )

--- a/tests/test_snmp_arguments.py
+++ b/tests/test_snmp_arguments.py
@@ -17,6 +17,26 @@ def test_arg_non_default_port():
     assert dev.port == 35000
 
 
+def test_arg_timeout_and_retries_defaults():
+    dev = SnmpHandler(
+        host='1.1.1.1',
+        version='2c',
+        community='public',)
+    assert dev.timeout == 1
+    assert dev.retries == 5
+
+
+def test_arg_timeout_and_retries():
+    dev = SnmpHandler(
+        host='1.1.1.1',
+        version='2c',
+        community='public',
+        timeout=4,
+        retries=10)
+    assert dev.timeout == 4
+    assert dev.retries == 10
+
+
 def test_snmp_handler_v3_authpriv():
     dev = SnmpHandler(
         host='1.1.1.1', version='3', username='user',


### PR DESCRIPTION
Currently, the pysnmp default for timeout and retries is not configureable. This is a desirable feature for some use cases, such as running automated tests.

This commit introduces support for timeout and retries and defines their defaults to be those of pysnmp (1 and 5, respectively).
